### PR TITLE
SwingConsolePane: do not catch window focus in show if window is visible

### DIFF
--- a/src/main/java/org/scijava/ui/swing/console/SwingConsolePane.java
+++ b/src/main/java/org/scijava/ui/swing/console/SwingConsolePane.java
@@ -7,13 +7,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -115,7 +115,8 @@ public class SwingConsolePane extends AbstractConsolePane<JPanel> {
 
 			@Override
 			public void run() {
-				window.setVisible(true);
+			    if (!window.isVisible())
+			        window.setVisible(true);
 			}
 		});
 	}


### PR DESCRIPTION
If the console window is already visible, it must not take focus
on show() calls because this leads to an unusable desktop if an
application generates continuous output at System.err which triggers
show() by AbstractConsolePane.outputOccurred(e)).