### PR TITLE
Update console on the EDT only

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,12 @@
 			<artifactId>jdatepicker</artifactId>
 			<version>1.3.2</version>
 		</dependency>
+
+		<!-- Test scope dependencies -->
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/org/scijava/ui/swing/console/SwingConsolePane.java
+++ b/src/main/java/org/scijava/ui/swing/console/SwingConsolePane.java
@@ -110,14 +110,12 @@ public class SwingConsolePane extends AbstractConsolePane<JPanel> {
 
 	@Override
 	public void show() {
-		if (window == null) return;
+		if (window == null || window.isVisible()) return;
 		threadService.queue(new Runnable() {
 
 			@Override
 			public void run() {
-				if (!window.isVisible()) {
-					window.setVisible(true);
-				}
+				window.setVisible(true);
 			}
 		});
 	}

--- a/src/main/java/org/scijava/ui/swing/console/SwingConsolePane.java
+++ b/src/main/java/org/scijava/ui/swing/console/SwingConsolePane.java
@@ -92,6 +92,16 @@ public class SwingConsolePane extends AbstractConsolePane<JPanel> {
 		this.window = window;
 	}
 
+	public JTextPane getTextPane() {
+		if (consolePanel == null) initConsolePanel();
+		return textPane;
+	}
+
+	public JScrollPane getScrollPane() {
+		if (consolePanel == null) initConsolePanel();
+		return scrollPane;
+	}
+
 	// -- ConsolePane methods --
 
 	@Override

--- a/src/main/java/org/scijava/ui/swing/console/SwingConsolePane.java
+++ b/src/main/java/org/scijava/ui/swing/console/SwingConsolePane.java
@@ -51,7 +51,6 @@ import org.scijava.console.OutputEvent;
 import org.scijava.console.OutputEvent.Source;
 import org.scijava.plugin.Parameter;
 import org.scijava.thread.ThreadService;
-import org.scijava.ui.UIService;
 import org.scijava.ui.console.AbstractConsolePane;
 import org.scijava.ui.console.ConsolePane;
 import org.scijava.ui.swing.StaticSwingUtils;
@@ -192,29 +191,6 @@ public class SwingConsolePane extends AbstractConsolePane<JPanel> {
 		final boolean contextual = event.isContextual();
 		if (stderr) return contextual ? stderrLocal : stderrGlobal;
 		return contextual ? stdoutLocal : stdoutGlobal;
-	}
-
-	// -- Main method --
-
-	/** A manual test drive of the Swing UI's console pane. */
-	public static void main(final String[] args) throws Exception {
-		final Context context = new Context();
-		context.service(UIService.class).showUI();
-
-		System.out.println("Hello!");
-
-		final ThreadService threadService = context.service(ThreadService.class);
-		threadService.run(new Runnable() {
-
-			@Override
-			public void run() {
-				System.out.println("This is a test of the emergency console system.");
-				System.err.println("In a real emergency, your computer would explode.");
-			}
-
-		}).get();
-
-		System.err.println("Goodbye!");
 	}
 
 }

--- a/src/main/java/org/scijava/ui/swing/console/SwingConsolePane.java
+++ b/src/main/java/org/scijava/ui/swing/console/SwingConsolePane.java
@@ -98,14 +98,21 @@ public class SwingConsolePane extends AbstractConsolePane<JPanel> {
 	@Override
 	public void append(final OutputEvent event) {
 		if (consolePanel == null) initConsolePanel();
-		final boolean atBottom = StaticSwingUtils.isScrolledToBottom(scrollPane);
-		try {
-			doc.insertString(doc.getLength(), event.getOutput(), getStyle(event));
-		}
-		catch (final BadLocationException exc) {
-			throw new RuntimeException(exc);
-		}
-		if (atBottom) StaticSwingUtils.scrollToBottom(scrollPane);
+		threadService.queue(new Runnable() {
+
+			@Override
+			public void run() {
+				final boolean atBottom =
+					StaticSwingUtils.isScrolledToBottom(scrollPane);
+				try {
+					doc.insertString(doc.getLength(), event.getOutput(), getStyle(event));
+				}
+				catch (final BadLocationException exc) {
+					throw new RuntimeException(exc);
+				}
+				if (atBottom) StaticSwingUtils.scrollToBottom(scrollPane);
+			}
+		});
 	}
 
 	@Override

--- a/src/main/java/org/scijava/ui/swing/console/SwingConsolePane.java
+++ b/src/main/java/org/scijava/ui/swing/console/SwingConsolePane.java
@@ -35,6 +35,7 @@ import java.awt.Color;
 import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.Font;
+import java.util.concurrent.ConcurrentLinkedQueue;
 
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
@@ -81,6 +82,13 @@ public class SwingConsolePane extends AbstractConsolePane<JPanel> {
 	 */
 	private Component window;
 
+	/** Output queue, to avoid excessive queuing to the EDT. */
+	private ConcurrentLinkedQueue<OutputEvent> outputQueue =
+		new ConcurrentLinkedQueue<OutputEvent>();
+
+	/** Flag indicating that the EDT is currently flushing the output. */
+	private boolean outputFlushing;
+
 	public SwingConsolePane(final Context context) {
 		super(context);
 	}
@@ -107,19 +115,29 @@ public class SwingConsolePane extends AbstractConsolePane<JPanel> {
 	@Override
 	public void append(final OutputEvent event) {
 		if (consolePanel == null) initConsolePanel();
+		outputQueue.add(event);
+		if (outputFlushing) return;
+		outputFlushing = true;
+
 		threadService.queue(new Runnable() {
 
 			@Override
 			public void run() {
-				final boolean atBottom =
-					StaticSwingUtils.isScrolledToBottom(scrollPane);
-				try {
-					doc.insertString(doc.getLength(), event.getOutput(), getStyle(event));
+				while (true) {
+					outputFlushing = !outputQueue.isEmpty();
+					final OutputEvent item = outputQueue.poll();
+					if (item == null) break;
+
+					final boolean atBottom =
+						StaticSwingUtils.isScrolledToBottom(scrollPane);
+					try {
+						doc.insertString(doc.getLength(), item.getOutput(), getStyle(item));
+					}
+					catch (final BadLocationException exc) {
+						throw new RuntimeException(exc);
+					}
+					if (atBottom) StaticSwingUtils.scrollToBottom(scrollPane);
 				}
-				catch (final BadLocationException exc) {
-					throw new RuntimeException(exc);
-				}
-				if (atBottom) StaticSwingUtils.scrollToBottom(scrollPane);
 			}
 		});
 	}

--- a/src/test/java/org/scijava/ui/swing/console/SwingConsolePaneBenchmark.java
+++ b/src/test/java/org/scijava/ui/swing/console/SwingConsolePaneBenchmark.java
@@ -1,0 +1,67 @@
+/*
+ * #%L
+ * SciJava UI components for Java Swing.
+ * %%
+ * Copyright (C) 2010 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package org.scijava.ui.swing.console;
+
+import org.scijava.Context;
+import org.scijava.thread.ThreadService;
+import org.scijava.ui.UIService;
+
+/**
+ * A behavioral test and benchmark of {@link SwingConsolePane}.
+ *
+ * @author Curtis Rueden
+ */
+public class SwingConsolePaneBenchmark {
+
+	// -- Main method --
+
+	/** A manual test drive of the Swing UI's console pane. */
+	public static void main(final String[] args) throws Exception {
+		final Context context = new Context();
+		context.service(UIService.class).showUI();
+
+		System.out.println("Hello!");
+
+		final ThreadService threadService = context.service(ThreadService.class);
+		threadService.run(new Runnable() {
+
+			@Override
+			public void run() {
+				System.out.println("This is a test of the emergency console system.");
+				System.err.println("In a real emergency, your computer would explode.");
+			}
+
+		}).get();
+
+		System.err.println("Goodbye!");
+	}
+
+}


### PR DESCRIPTION
This branch updates the Swing output console so that updates happen only on the AWT Event Dispatch Thread (EDT). See [this IRC discussion on #fiji-devel](http://code.imagej.net/chatlogs/fiji-devel?start-date=2015-04-14&end-date=2015-04-15&times=sparse) for further details on the issue being resolved.

@axtimwalde Before merging, I would appreciate if you would test a couple of things:

1. I'd like to know that this change actually does address your issues with output from TrakEM2.
2. Furthermore, I'm worried about the last commit in the series, that attempts to batch the output events. Given the results of some performance benchmarks I did (see the `SwingConsolePaneBenchmark` class, and the explanation in 881065a3f649e197a8cf5536db85e607ed9c70ea), it may not be worth batching the output events, since doing so might risk incorrect behavior in pursuit of an inadequate performance improvement.

So, could you please test:
* The tip of this branch.
* The branch with 881065a3f649e197a8cf5536db85e607ed9c70ea reverted.

And let me know if it improves the situation for your TrakEM2 use case?

Thanks! 