### PR TITLE
Fix trailing new line in walk()

### DIFF
--- a/src/main/java/org/scijava/ui/swing/script/PromptPane.java
+++ b/src/main/java/org/scijava/ui/swing/script/PromptPane.java
@@ -147,7 +147,7 @@ public abstract class PromptPane implements UIComponent<JTextArea> {
 
 	private void walk(boolean forward) {
 		textArea.setText(repl.getInterpreter().walkHistory(textArea.getText(),
-			forward));
+			forward).trim());
 	}
 
 	private synchronized boolean execute() {


### PR DESCRIPTION
Before when walking the history, a trailing `\n` got appended to the
submitted command. Unfortunately, these accumulated over time. This commit
adds a `trim()` to get rid of leading/trailing whitespace.