### PR TITLE
Expose REPL for use in InterpreterWindow

### DIFF
--- a/src/main/java/org/scijava/ui/swing/script/InterpreterWindow.java
+++ b/src/main/java/org/scijava/ui/swing/script/InterpreterWindow.java
@@ -30,14 +30,15 @@
 
 package org.scijava.ui.swing.script;
 
-import javax.swing.JFrame;
-import javax.swing.WindowConstants;
-
 import org.scijava.Context;
 import org.scijava.log.LogService;
 import org.scijava.plugin.Parameter;
 import org.scijava.prefs.PrefService;
+import org.scijava.script.ScriptInterpreter;
+import org.scijava.script.ScriptREPL;
 import org.scijava.script.ScriptService;
+
+import javax.swing.*;
 
 /**
  * The main interpreter window.
@@ -75,6 +76,16 @@ public class InterpreterWindow extends JFrame {
 		pack();
 
 		setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
+	}
+
+	/** Returns the @link{ScriptREPL} associated to the InterpreterWindow **/
+	public ScriptREPL getREPL() {
+		return pane.getREPL();
+	}
+
+	/** Returns the @link{ScriptInterpreter} associated with the REPL directly **/
+	public ScriptInterpreter getInterpreter() {
+		return pane.getREPL().getInterpreter();
 	}
 
 	@Override


### PR DESCRIPTION
This PR exposes the REPL and ScriptInterpreter of the InterpreterPane in the InterpreterWindow, so it may be used programmatically, e.g.

```java
final InterpreterWindow iw = new InterpreterWindow(...);
iw.getREPL().getInterpreter().eval(...);
// or
iw.getInterpreter().eval();
```