### PR TITLE
Support named objects in (Swing)ObjectWidget

### DIFF
--- a/src/main/java/org/scijava/ui/swing/widget/SwingObjectWidget.java
+++ b/src/main/java/org/scijava/ui/swing/widget/SwingObjectWidget.java
@@ -29,12 +29,18 @@
 
 package org.scijava.ui.swing.widget;
 
+import java.awt.Component;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 
+import javax.swing.DefaultListCellRenderer;
 import javax.swing.JComboBox;
+import javax.swing.JLabel;
+import javax.swing.JList;
 import javax.swing.JPanel;
+import javax.swing.ListCellRenderer;
 
+import org.scijava.object.ObjectService;
 import org.scijava.plugin.Plugin;
 import org.scijava.widget.InputWidget;
 import org.scijava.widget.ObjectWidget;
@@ -76,6 +82,7 @@ public class SwingObjectWidget extends SwingInputWidget<Object> implements
 		setToolTip(comboBox);
 		getComponent().add(comboBox);
 		comboBox.addActionListener(this);
+		comboBox.setRenderer(new NamedObjectCellRenderer());
 
 		refreshWidget();
 	}
@@ -96,4 +103,17 @@ public class SwingObjectWidget extends SwingInputWidget<Object> implements
 		comboBox.setSelectedItem(value);
 	}
 
+	private class NamedObjectCellRenderer implements ListCellRenderer<Object> {
+		
+		private DefaultListCellRenderer defaultRenderer = new DefaultListCellRenderer();
+
+		@Override
+		public Component getListCellRendererComponent(JList<?> list, Object value, int index, boolean isSelected,
+				boolean cellHasFocus) {
+			JLabel renderer = (JLabel) defaultRenderer.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
+			renderer.setText(context().service(ObjectService.class).getName(value));
+			renderer.setToolTipText(value.toString());
+			return renderer;
+		}
+	}
 }


### PR DESCRIPTION
The dropdown list now shows the object names (retrieved by `ObjectService.getName`), while the tooltip shows the object's `toString()` value for each entry.

This allows using arbitrary object parameters (provided the objects have been registered to the `ObjectService` first) as follows:

```
#@ net.imglib2.realtransform.AffineGet affine

println affine
```

![image](https://user-images.githubusercontent.com/2033938/72323147-4e0b7200-36a8-11ea-9b21-f7f228756f17.png)

This is a follow-up to https://github.com/scijava/scijava-common/pull/374 and <s>will require a new release of `scijava-common` in order to remove the temporary version pinning</s>.

**Edit**: I now removed the version property definition for `scijava-common`, since `pom-scijava-28.0.0` manages `scijava-common-2.82.0`.
