### PR TITLE
Add SwingColorAlphaWidget

### DIFF
--- a/src/main/java/org/scijava/ui/swing/widget/SwingColorWidget.java
+++ b/src/main/java/org/scijava/ui/swing/widget/SwingColorWidget.java
@@ -51,6 +51,7 @@ import javax.swing.colorchooser.AbstractColorChooserPanel;
 import org.scijava.plugin.Plugin;
 import org.scijava.ui.awt.AWTColors;
 import org.scijava.util.ColorRGB;
+import org.scijava.util.ColorRGBA;
 import org.scijava.widget.ColorWidget;
 import org.scijava.widget.InputWidget;
 import org.scijava.widget.WidgetModel;
@@ -78,6 +79,7 @@ public class SwingColorWidget extends SwingInputWidget<ColorRGB> implements
 
 	private JButton choose;
 	private Color color;
+	private boolean useAlpha = false;
 
 	// -- ActionListener methods --
 
@@ -94,6 +96,7 @@ public class SwingColorWidget extends SwingInputWidget<ColorRGB> implements
 
 	@Override
 	public ColorRGB getValue() {
+		if(useAlpha) return AWTColors.getColorRGBA(color);
 		return AWTColors.getColorRGB(color);
 	}
 
@@ -212,11 +215,13 @@ public class SwingColorWidget extends SwingInputWidget<ColorRGB> implements
 
 	@Override
 	public void doRefresh() {
+		useAlpha = get().isType(ColorRGBA.class);
 		final ColorRGB value = (ColorRGB) get().getValue();
 		color = AWTColors.getColor(value);
 
+		int imageType = useAlpha ? BufferedImage.TYPE_INT_ARGB : BufferedImage.TYPE_INT_RGB;
 		final BufferedImage image =
-			new BufferedImage(SWATCH_WIDTH, SWATCH_HEIGHT, BufferedImage.TYPE_INT_RGB);
+			new BufferedImage(SWATCH_WIDTH, SWATCH_HEIGHT, imageType);
 		final Graphics g = image.getGraphics();
 		g.setColor(color);
 		g.fillRect(0, 0, image.getWidth(), image.getHeight());

--- a/src/test/java/org/scijava/ui/swing/widget/SwingColorWidgetDemo.java
+++ b/src/test/java/org/scijava/ui/swing/widget/SwingColorWidgetDemo.java
@@ -1,0 +1,63 @@
+/*
+ * #%L
+ * SciJava UI components for Java Swing.
+ * %%
+ * Copyright (C) 2010 - 2020 SciJava developers.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package org.scijava.ui.swing.widget;
+
+import org.scijava.Context;
+import org.scijava.command.Command;
+import org.scijava.command.CommandService;
+import org.scijava.log.LogService;
+import org.scijava.plugin.Parameter;
+import org.scijava.ui.UIService;
+import org.scijava.util.ColorRGB;
+import org.scijava.util.ColorRGBA;
+
+public class SwingColorWidgetDemo implements Command {
+
+	@Parameter
+	private ColorRGBA colorRGBA;
+
+	@Parameter
+	private ColorRGB colorRGB;
+
+	@Parameter
+	private LogService logService;
+
+	@Override
+	public void run() {
+		logService.info(colorRGB.getRed() + " " + colorRGB.getGreen() + " " + colorRGB.getBlue() + " " + colorRGB.getAlpha());
+		logService.info(colorRGBA.getRed() + " " + colorRGBA.getGreen() + " " + colorRGBA.getBlue() + " " + colorRGBA.getAlpha());
+	}
+
+	public static void main(final String... args) {
+		Context context = new Context();
+		context.service(UIService.class).showUI();
+		context.service(CommandService.class).run(SwingColorWidgetDemo.class, true);
+	}
+}


### PR DESCRIPTION
This PR makes it possible to use parameters of type`ColorRGBA`. Before, when using `ColorRGBA`, the `SwingColorWidget` would return `null` when changing the color because `ColorRGB` cannot be converted to `ColorRGBA` [here](https://github.com/scijava/scijava-common/blob/master/src/main/java/org/scijava/widget/DefaultWidgetModel.java#L166).

I just quickly copied the `SwingColorWidget` and replaced `ColorRGB` with `ColorRGBA` which makes it work (and also possible to assign colors with alpha value). Let me know if there is a cleaner solution and maybe a way to write a test.