### PR TITLE
Support Enums in SwingObjectWidget

### DIFF
--- a/src/main/java/org/scijava/ui/swing/widget/SwingObjectWidget.java
+++ b/src/main/java/org/scijava/ui/swing/widget/SwingObjectWidget.java
@@ -78,7 +78,12 @@ public class SwingObjectWidget extends SwingInputWidget<Object> implements
 	public void set(final WidgetModel model) {
 		super.set(model);
 
-		comboBox = new JComboBox<>(model.getObjectPool().toArray());
+		String[] availableChoices = model.getChoices();
+		if (availableChoices != null) {
+			comboBox = new JComboBox<>(availableChoices);
+		} else {
+			comboBox = new JComboBox<>(model.getObjectPool().toArray());
+		}
 		setToolTip(comboBox);
 		getComponent().add(comboBox);
 		comboBox.addActionListener(this);
@@ -91,7 +96,8 @@ public class SwingObjectWidget extends SwingInputWidget<Object> implements
 
 	@Override
 	public boolean supports(final WidgetModel model) {
-		return super.supports(model) && model.getObjectPool().size() > 0;
+		return super.supports(model) && (model.getChoices() != null ||
+			(model.getObjectPool() != null && model.getObjectPool().size() > 0));
 	}
 
 	// -- AbstractUIInputWidget methods ---

--- a/src/test/java/org/scijava/ui/swing/widget/SwingObjectWidgetTest.java
+++ b/src/test/java/org/scijava/ui/swing/widget/SwingObjectWidgetTest.java
@@ -1,0 +1,96 @@
+package org.scijava.ui.swing.widget;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.scijava.Context;
+import org.scijava.command.CommandInfo;
+import org.scijava.command.ContextCommand;
+import org.scijava.module.Module;
+import org.scijava.module.ModuleItem;
+import org.scijava.module.ModuleService;
+import org.scijava.plugin.Parameter;
+import org.scijava.widget.InputPanel;
+import org.scijava.widget.InputWidget;
+import org.scijava.widget.WidgetModel;
+import org.scijava.widget.WidgetService;
+
+public class SwingObjectWidgetTest {
+
+	private Context context;
+	private ModuleService moduleService;
+	private WidgetService widgetService;
+
+	@Before
+	public void setUp() {
+		context = new Context();
+		moduleService = context.getService(ModuleService.class);
+		widgetService = context.getService(WidgetService.class);
+	}
+
+	@After
+	public void tearDown() {
+		context.dispose();
+	}
+
+	@Test
+	public void testObjects() {
+		Thing a = new Thing();
+		Thing b = new Thing();
+
+		CommandInfo commandInfo = new CommandInfo(MyCommand.class);
+		Module module = moduleService.createModule(commandInfo);
+		InputPanel<?,?> panel = new SwingInputPanel();
+
+		ModuleItem<Thing> thingInput = moduleService.getSingleInput(module, Thing.class);
+		ModuleItem<Nothing> nothingInput = moduleService.getSingleInput(module, Nothing.class);
+		ModuleItem<Choices> choicesInput = moduleService.getSingleInput(module, Choices.class);
+
+		WidgetModel thingModel = widgetService.createModel(panel, module, thingInput, Arrays.asList(a, b));
+		WidgetModel nothingModel = widgetService.createModel(panel, module, nothingInput, null);
+		WidgetModel choicesModel = widgetService.createModel(panel, module, choicesInput, null);
+
+		InputWidget<?, ?> thingWidget = widgetService.create(thingModel);
+		assertTrue(thingWidget instanceof SwingObjectWidget);
+
+		InputWidget<?, ?> nothingWidget = widgetService.create(nothingModel);
+		assertFalse(nothingWidget instanceof SwingObjectWidget);
+
+		InputWidget<?, ?> choicesWidget = widgetService.create(choicesModel);
+		assertTrue(choicesWidget instanceof SwingObjectWidget);
+	}
+
+	private class Thing {
+		// dummy class
+	}
+
+	private class Nothing {
+		// dummy class
+	}
+
+	private enum Choices {
+		FIRST, SECOND, THIRD
+	};
+
+	public static class MyCommand extends ContextCommand {
+		@Parameter
+		private Thing thing;
+
+		@Parameter
+		private Nothing nothing;
+
+		@Parameter
+		private Choices choices;
+
+		@Override
+		public void run() {
+			// nothing to do
+		}
+
+	}
+}


### PR DESCRIPTION
For Enum parameters, model.getChoices() returns all available enum values by default, so let's just support any model that has valid choices.

This commit also adds a test for SwingObjectWidget, testing Enum parameters as well as Object parameters with and without objects in their object pool.

This PR currently depends on https://github.com/scijava/scijava-common/pull/400 that adds a required `null` check, so that PR should be merged and this one updated with a newer version of `scijava-common`.

Closes https://github.com/scijava/scijava-common/issues/397.