### PR TITLE
Update JComboBox choices during SwingChoiceWidget refresh

### DIFF
--- a/src/main/java/org/scijava/ui/swing/widget/SwingChoiceWidget.java
+++ b/src/main/java/org/scijava/ui/swing/widget/SwingChoiceWidget.java
@@ -67,7 +67,10 @@ public class SwingChoiceWidget extends SwingInputWidget<String> implements
 
 	@Override
 	public String getValue() {
-		return comboBox.getSelectedItem().toString();
+		if (comboBox.getItemCount() > 0)
+			return comboBox.getSelectedItem().toString();
+		else
+			return null;
 	}
 
 	// -- WrapperPlugin methods --
@@ -97,8 +100,35 @@ public class SwingChoiceWidget extends SwingInputWidget<String> implements
 
 	@Override
 	public void doRefresh() {
-		final Object value = get().getValue();
-		if (value.equals(comboBox.getSelectedItem())) return; // no change
-		comboBox.setSelectedItem(value);
+		final String[] choices = get().getChoices();
+		
+		if (!areListsEqual(choices, comboBoxItems())) {
+			comboBox.removeAllItems();	
+			for (int i=0; i<choices.length; i++)
+				comboBox.addItem(choices[i]);
+		} else {
+			final Object value = get().getValue();
+			if (value.equals(comboBox.getSelectedItem())) return;
+			comboBox.setSelectedItem(value);
+		}
+	}
+	
+	private boolean areListsEqual(String[] list1, String[] list2) {
+		if (list1.length != list2.length)
+			return false;
+		
+		for (int i=0; i< list1.length; i++)
+			if (!list1[i].equals(list2[i]))
+				return false;
+		
+		return true;
+	}
+	
+	private String[] comboBoxItems() {
+		String[] comboItems = new String[comboBox.getItemCount()];
+		for (int i=0; i <comboBox.getItemCount(); i++)
+			comboItems[i] = comboBox.getItemAt(i);
+		
+		return comboItems;
 	}
 }

--- a/src/main/java/org/scijava/ui/swing/widget/SwingChoiceWidget.java
+++ b/src/main/java/org/scijava/ui/swing/widget/SwingChoiceWidget.java
@@ -31,6 +31,7 @@ package org.scijava.ui.swing.widget;
 
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.util.Arrays;
 
 import javax.swing.JComboBox;
 import javax.swing.JPanel;
@@ -102,7 +103,7 @@ public class SwingChoiceWidget extends SwingInputWidget<String> implements
 	public void doRefresh() {
 		final String[] choices = get().getChoices();
 		
-		if (!areListsEqual(choices, comboBoxItems())) {
+		if (!Arrays.equals(choices, comboBoxItems())) {
 			comboBox.removeAllItems();	
 			for (int i=0; i<choices.length; i++)
 				comboBox.addItem(choices[i]);
@@ -111,17 +112,6 @@ public class SwingChoiceWidget extends SwingInputWidget<String> implements
 			if (value.equals(comboBox.getSelectedItem())) return;
 			comboBox.setSelectedItem(value);
 		}
-	}
-	
-	private boolean areListsEqual(String[] list1, String[] list2) {
-		if (list1.length != list2.length)
-			return false;
-		
-		for (int i=0; i< list1.length; i++)
-			if (!list1[i].equals(list2[i]))
-				return false;
-		
-		return true;
 	}
 	
 	private String[] comboBoxItems() {


### PR DESCRIPTION
Currently, JComboBox items are not updated during DynamicCallbacks as noted in the comments of the DynamicCallback example - https://github.com/imagej/tutorials/blob/d3ff8e818bb26cb4713371878b239b36cb7d4877/maven-projects/dynamic-commands/src/main/java/DynamicCallbacks.java#L29-L31

@imagejan suggested implementing JComboBox updates in the doRefresh() method of SwingChoiceWidget to fix this problem on the forum - https://forum.image.sc/t/repaint-scijava-command-ui/42835/2

I quickly wrote a draft of this so that changes in the options of the dialog can update the JComboBox items. This is very useful for situations where you want one JComboBox to change items based on another. 

Maybe there are deeper reasons to not implement a fix in this manner. Also, there might be cleaner implementations, but since I was already testing, I figured I would go ahead and file the PR.