### PR TITLE
Improve number format in SwingNumberWidget

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>29.2.1</version>
+		<version>30.0.0</version>
 		<relativePath />
 	</parent>
 
@@ -107,6 +107,8 @@
 
 		<jdatepicker.version>1.3.2</jdatepicker.version>
 		<object-inspector.version>0.1</object-inspector.version>
+
+		<scijava-common.version>2.87.0</scijava-common.version>
 	</properties>
 
 	<repositories>
@@ -144,7 +146,6 @@
 		<dependency>
 			<groupId>com.miglayout</groupId>
 			<artifactId>miglayout-swing</artifactId>
-			<version>${miglayout-swing.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>net.sourceforge.jdatepicker</groupId>
@@ -158,5 +159,13 @@
 			<artifactId>junit</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<!-- NB: inherit the BindingSizes script engine from scijava-common -->
+		<dependency>
+			<groupId>org.scijava</groupId>
+			<artifactId>scijava-common</artifactId>
+			<classifier>tests</classifier>
+			<scope>test</scope>
+		</dependency>
+
 	</dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>28.0.0</version>
+		<version>29.2.1</version>
 		<relativePath />
 	</parent>
 
@@ -107,9 +107,6 @@
 
 		<jdatepicker.version>1.3.2</jdatepicker.version>
 		<object-inspector.version>0.1</object-inspector.version>
-
-		<miglayout-swing.version>5.2</miglayout-swing.version>
-		<scijava-ui-awt.version>0.1.7</scijava-ui-awt.version>
 	</properties>
 
 	<repositories>

--- a/src/main/java/org/scijava/ui/swing/widget/SwingNumberWidget.java
+++ b/src/main/java/org/scijava/ui/swing/widget/SwingNumberWidget.java
@@ -41,6 +41,8 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.text.DecimalFormat;
 import java.text.ParsePosition;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Hashtable;
 
 import javax.swing.JComponent;
@@ -62,6 +64,7 @@ import org.scijava.thread.ThreadService;
 import org.scijava.widget.InputWidget;
 import org.scijava.widget.NumberWidget;
 import org.scijava.widget.WidgetModel;
+import org.scijava.widget.WidgetStyle;
 
 /**
  * Swing implementation of number chooser widget.
@@ -119,10 +122,11 @@ public class SwingNumberWidget extends SwingInputWidget<Number> implements
 		final SpinnerNumberModel spinnerModel =
 			new SpinnerNumberModelFactory().createModel(value, min, max, stepSize);
 		spinner = new JSpinner(spinnerModel);
-		String format = getFormat(model);
-		if (format != null) {
-			spinner.setEditor(new JSpinner.NumberEditor(spinner, format));
+		String format = WidgetStyle.getStyleModifier(model.getItem().getWidgetStyle(), "format");
+		if (format == null) {
+			format = suitableFormat(value, stepSize, min, max);
 		}
+		spinner.setEditor(new JSpinner.NumberEditor(spinner, format));
 
 		Dimension spinnerSize = spinner.getSize();
 		spinnerSize.width = 50;
@@ -135,17 +139,6 @@ public class SwingNumberWidget extends SwingInputWidget<Number> implements
 
 		refreshWidget();
 		syncSliders();
-	}
-
-	private String getFormat(WidgetModel model) {
-		final String widgetStyle = model.getItem().getWidgetStyle();
-		String format = null;
-		for (final String s : widgetStyle.split(",")) {
-			if (s.startsWith("format:")) {
-				format = s.substring(s.indexOf(":") + 1).trim();
-			}
-		}
-		return format;
 	}
 
 	// -- Typed methods --
@@ -343,6 +336,20 @@ public class SwingNumberWidget extends SwingInputWidget<Number> implements
 			scrollBar.setCalibratedValue(value);
 			scrollBar.addAdjustmentListener(this);
 		}
+	}
+
+	/** Generate a suitable format pattern. */
+	private String suitableFormat(Number... values) {
+		Integer maxScale = Arrays.stream(values)
+				.map(n -> new BigDecimal("" + n.doubleValue()).stripTrailingZeros().scale()).max(Integer::compare)
+				.get();
+		return formatForScale(maxScale);
+	}
+
+	/** Generate a format pattern with sufficient number of decimals. */
+	private String formatForScale(int scale) {
+		if (scale <= 0) return "0";
+		return "0." + String.join("", Collections.nCopies(scale, "0"));
 	}
 
 	// -- AbstractUIInputWidget methods ---

--- a/src/main/java/org/scijava/ui/swing/widget/SwingNumberWidget.java
+++ b/src/main/java/org/scijava/ui/swing/widget/SwingNumberWidget.java
@@ -119,6 +119,11 @@ public class SwingNumberWidget extends SwingInputWidget<Number> implements
 		final SpinnerNumberModel spinnerModel =
 			new SpinnerNumberModelFactory().createModel(value, min, max, stepSize);
 		spinner = new JSpinner(spinnerModel);
+		String format = getFormat(model);
+		if (format != null) {
+			spinner.setEditor(new JSpinner.NumberEditor(spinner, format));
+		}
+
 		Dimension spinnerSize = spinner.getSize();
 		spinnerSize.width = 50;
 		spinner.setPreferredSize(spinnerSize);
@@ -130,6 +135,17 @@ public class SwingNumberWidget extends SwingInputWidget<Number> implements
 
 		refreshWidget();
 		syncSliders();
+	}
+
+	private String getFormat(WidgetModel model) {
+		final String widgetStyle = model.getItem().getWidgetStyle();
+		String format = null;
+		for (final String s : widgetStyle.split(",")) {
+			if (s.startsWith("format:")) {
+				format = s.substring(s.indexOf(":") + 1).trim();
+			}
+		}
+		return format;
 	}
 
 	// -- Typed methods --

--- a/src/test/java/org/scijava/ui/swing/widget/SwingNumberWidgetDemo.java
+++ b/src/test/java/org/scijava/ui/swing/widget/SwingNumberWidgetDemo.java
@@ -1,0 +1,69 @@
+package org.scijava.ui.swing.widget;
+
+import org.scijava.Context;
+import org.scijava.command.Command;
+import org.scijava.command.CommandService;
+import org.scijava.plugin.Parameter;
+import org.scijava.ui.UIService;
+
+public class SwingNumberWidgetDemo implements Command {
+
+	@Parameter(persist = false)
+	private Double a = 0.0000123;
+
+	@Parameter(persist = false)
+	private Double b = 0.000123;
+
+	@Parameter(persist = false)
+	private Double c = 0.00123;
+
+	@Parameter(persist = false)
+	private Double d = 0.0123;
+
+	@Parameter(persist = false)
+	private Double e = 0.123;
+
+	@Parameter(persist = false)
+	private Double f = 1.23;
+
+	@Parameter(persist = false)
+	private Double g = 123d;
+
+	@Parameter(min = "0.0", max = "10.0", stepSize = "0.001", persist = false)
+	private Double h = 1d;
+
+	@Parameter(style = "format:#.##", persist = false)
+	private Double i = 0.0123;
+
+	@Parameter(style = "format:#.00", persist = false)
+	private Double j = 0.0123;
+
+	@Parameter(style = "format:#####.#####", persist = false)
+	private Double k = 123.45;
+
+	@Parameter(style = "format:00000.00000", persist = false)
+	private Double l = 123.45;
+
+	@Parameter(style = "slider", min = "0", max = "10", stepSize = "0.001", persist = false)
+	private Double m = 1d;
+
+	@Parameter(style = "slider,format:0.0000", min = "0", max = "10", stepSize = "0.001", persist = false)
+	private Double n = 1d;
+
+	@Parameter(style = "scroll bar", min = "0", max = "10", stepSize = "0.001", persist = false)
+	private Double o = 1d;
+
+	@Parameter(style = "scroll bar,format:0.0000", min = "0", max = "10", stepSize = "0.001", persist = false)
+	private Double p = 1d;
+
+	@Override
+	public void run() {
+		// Nothing to do.
+	}
+
+	public static void main(final String... args) throws Exception {
+		Context context = new Context();
+		context.service(UIService.class).showUI();
+		context.service(CommandService.class).run(SwingNumberWidgetDemo.class, true);
+	}
+}

--- a/src/test/java/org/scijava/ui/swing/widget/SwingNumberWidgetTest.java
+++ b/src/test/java/org/scijava/ui/swing/widget/SwingNumberWidgetTest.java
@@ -1,0 +1,148 @@
+/*-
+ * #%L
+ * SciJava UI components for Java Swing.
+ * %%
+ * Copyright (C) 2010 - 2020 SciJava developers.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package org.scijava.ui.swing.widget;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.StringReader;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Collections;
+
+import javax.swing.JSpinner;
+import javax.swing.JSpinner.NumberEditor;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.scijava.Context;
+import org.scijava.module.Module;
+import org.scijava.module.ModuleException;
+import org.scijava.module.ModuleItem;
+import org.scijava.module.ModuleService;
+import org.scijava.script.ScriptInfo;
+import org.scijava.script.ScriptService;
+import org.scijava.util.ListUtils;
+import org.scijava.widget.InputWidget;
+import org.scijava.widget.WidgetModel;
+import org.scijava.widget.WidgetService;
+
+public class SwingNumberWidgetTest {
+
+	private Context context;
+	private ModuleService moduleService;
+	private WidgetService widgetService;
+
+	@Before
+	public void setUp() {
+		context = new Context();
+		moduleService = context.service(ModuleService.class);
+		widgetService = context.service(WidgetService.class);
+	}
+
+	@After
+	public void tearDown() {
+		context.dispose();
+	}
+
+	@Test
+	public void test() throws NoSuchFieldException, SecurityException, IllegalArgumentException, IllegalAccessException, ModuleException {
+		String[] expecteds = getExpectedValues();
+		Field spinnerField = SwingNumberWidget.class.getDeclaredField("spinner");
+		spinnerField.setAccessible(true);
+		
+		String script = createScript();
+		ScriptInfo info = new ScriptInfo(context, ".bsizes", new StringReader(script));
+		//System.err.println(moduleService);
+		Module module = moduleService.createModule(info);
+		//Module module = info.createModule();
+		Iterable<ModuleItem<?>> inputs = info.inputs();
+		SwingInputPanel inputPanel = new SwingInputPanel();
+		int i = 0;
+		for (ModuleItem<?> item : inputs) {
+			WidgetModel model = widgetService.createModel(inputPanel, module, item, Collections.EMPTY_LIST);
+			InputWidget<?, ?> inputWidget = widgetService.create(model);
+			assertTrue(inputWidget instanceof SwingNumberWidget);
+
+			JSpinner spinner = (JSpinner) spinnerField.get(inputWidget);
+			NumberEditor editor = (NumberEditor) spinner.getEditor();
+			assertEquals("Format (index " + i + ")", expecteds[i++], editor.getTextField().getText());
+		}
+	}
+
+	private String[] getExpectedValues() {
+		return new String[] {
+				"0.0000123",
+				"0.000123",
+				"0.00123",
+				"0.0123",
+				"0.123",
+				"1.23",
+				"123",
+				"1.000",
+				"0.01",
+				".01",
+				"123.45",
+				"00123.45000",
+				"1.000",
+				"1.0000",
+				"1.000",
+				"1.0000"
+		};
+	}
+
+	private String createScript() {
+		final String script = "// Automatically generated format\n" + 
+				"#@ Double (value=0.0000123, persist=false) a\n" + 
+				"#@ Double (value=0.000123, persist=false) b\n" + 
+				"#@ Double (value=0.00123, persist=false) c\n" + 
+				"#@ Double (value=0.0123, persist=false) d\n" + 
+				"#@ Double (value=0.123, persist=false) e\n" + 
+				"#@ Double (value=1.23, persist=false) f\n" + 
+				"#@ Double (value=123, persist=false) g\n" + 
+				"#@ Double (value=1, min=0.0, max=10.0, stepSize=0.001, persist=false) h\n" + 
+				"\n" + 
+				"// Specified format\n" + 
+				"#@ Double (value=0.0123, persist=false, style=\"format:#.##\") i\n" + 
+				"#@ Double (value=0.0123, persist=false, style=\"format:#.00\") j\n" + 
+				"#@ Double (value=123.45, persist=false, style=\"format:#####.#####\") k\n" + 
+				"#@ Double (value=123.45, persist=false, style=\"format:00000.00000\") l\n" + 
+				"\n" + 
+				"// Sliders and scroll bars\n" + 
+				"#@ Double (value=1, min=0, max=10, stepSize=0.001, persist=false, style=slider) m\n" + 
+				"#@ Double (value=1, min=0, max=10, stepSize=0.001, persist=false, style=\"slider,format:0.0000\") n\n" + 
+				"#@ Double (value=1, min=0, max=10, stepSize=0.001, persist=false, style=\"scroll bar\") o\n" + 
+				"#@ Double (value=1, min=0, max=10, stepSize=0.001, persist=false, style=\"scroll bar,format:0.0000\") p\n" + 
+				"";
+		return script;
+	}
+
+}


### PR DESCRIPTION
This pull request depends on https://github.com/scijava/scijava-common/pull/405 and supersedes #52.

It includes the changes by @BoudewijnvanLangerak (in #52) as a squashed commit.

Changes can be tested with `SwingNumberWidgetDemo` added here, or with the following script:

```groovy
// Automatically generated format
#@ Double (value=0.0000123, persist=false) a
#@ Double (value=0.000123, persist=false) b
#@ Double (value=0.00123, persist=false) c
#@ Double (value=0.0123, persist=false) d
#@ Double (value=0.123, persist=false) e
#@ Double (value=1.23, persist=false) f
#@ Double (value=123, persist=false) g
#@ Double (value=1, min=0.0, max=10.0, stepSize=0.001, persist=false) h

// Specified format
#@ Double (value=0.0123, persist=false, style="format:#.##") i
#@ Double (value=0.0123, persist=false, style="format:#.00") j
#@ Double (value=123.45, persist=false, style="format:#####.#####") k
#@ Double (value=123.45, persist=false, style="format:00000.00000") l

// Sliders and scroll bars
#@ Double (value=1, min=0, max=10, stepSize=0.001, persist=false, style=slider) m
#@ Double (value=1, min=0, max=10, stepSize=0.001, persist=false, style="slider,format:0.0000") n
#@ Double (value=1, min=0, max=10, stepSize=0.001, persist=false, style="scroll bar") o
#@ Double (value=1, min=0, max=10, stepSize=0.001, persist=false, style="scroll bar,format:0.0000") p
```

Here's a visual comparison before and after the changes in this commit:

<img width="216" alt="Screenshot 2020-11-01 at 15 42 28" src="https://user-images.githubusercontent.com/2033938/97806686-3912c600-1c5d-11eb-8f6a-904381c1d615.png"> <img width="245" alt="Screenshot 2020-11-01 at 16 07 49" src="https://user-images.githubusercontent.com/2033938/97806698-43cd5b00-1c5d-11eb-90ff-57a546226eb7.png">

(Fixes https://github.com/scijava/scijava-ui-swing/issues/45.)