### PR TITLE
Console: Do not used hardwired font sizes

### DIFF
--- a/src/main/java/org/scijava/ui/swing/AbstractSwingUI.java
+++ b/src/main/java/org/scijava/ui/swing/AbstractSwingUI.java
@@ -31,8 +31,6 @@ package org.scijava.ui.swing;
 
 import java.awt.BorderLayout;
 import java.awt.Component;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.io.File;
@@ -323,13 +321,7 @@ public abstract class AbstractSwingUI extends AbstractUserInterface implements
 		final JMenu edit = new JMenu("Edit");
 		menuBar.add(edit);
 		final JMenuItem editClear = new JMenuItem("Clear");
-		editClear.addActionListener(new ActionListener() {
-
-			@Override
-			public void actionPerformed(ActionEvent e) {
-				getConsolePane().clear();
-			}
-		});
+		editClear.addActionListener(e -> getConsolePane().clear());
 		edit.add(editClear);
 		return menuBar;
 	}

--- a/src/main/java/org/scijava/ui/swing/console/ConsolePanel.java
+++ b/src/main/java/org/scijava/ui/swing/console/ConsolePanel.java
@@ -35,10 +35,13 @@ import java.awt.Dimension;
 import java.awt.Font;
 import java.awt.FontMetrics;
 
+import javax.swing.JMenuItem;
 import javax.swing.JPanel;
+import javax.swing.JPopupMenu;
 import javax.swing.JScrollPane;
 import javax.swing.JTextArea;
 import javax.swing.JTextPane;
+import javax.swing.KeyStroke;
 import javax.swing.text.BadLocationException;
 import javax.swing.text.Style;
 import javax.swing.text.StyleConstants;
@@ -109,7 +112,7 @@ public class ConsolePanel extends JPanel implements OutputListener
 		setLayout(new MigLayout("inset 0", "[grow,fill]", "[grow,fill,align top]"));
 
 		textPane = new JTextPane();
-		textPane.setFont(new Font(Font.MONOSPACED, Font.PLAIN, 12));
+		textPane.setFont(new Font(Font.MONOSPACED, Font.PLAIN, textPane.getFont().getSize()));
 		textPane.setEditable(false);
 
 		doc = textPane.getStyledDocument();
@@ -137,9 +140,23 @@ public class ConsolePanel extends JPanel implements OutputListener
 		final int lineHeight = fm.getHeight();
 		scrollPane.getHorizontalScrollBar().setUnitIncrement(charWidth);
 		scrollPane.getVerticalScrollBar().setUnitIncrement(2 * lineHeight);
-
+		textPane.setComponentPopupMenu(initMenu());
 		add(scrollPane);
 	}
+
+	private JPopupMenu initMenu() {
+		final JPopupMenu menu = new JPopupMenu();
+		JMenuItem item = new JMenuItem("Copy");
+		item.setAccelerator(KeyStroke.getKeyStroke("control C"));
+		item.addActionListener( e-> textPane.copy());
+		menu.add(item);
+		item = new JMenuItem("Clear");
+		item.setAccelerator(KeyStroke.getKeyStroke("alt C"));
+		item.addActionListener(e -> clear());
+		menu.add(item);
+		return menu;
+	}
+
 	// -- Helper methods --
 
 	private Style createStyle(final String name, final Style parent,

--- a/src/main/java/org/scijava/ui/swing/console/ItemTextPane.java
+++ b/src/main/java/org/scijava/ui/swing/console/ItemTextPane.java
@@ -85,7 +85,7 @@ class ItemTextPane {
 	ItemTextPane(final Context context) {
 		context.inject(this);
 		textPane.setEditable(false);
-		textPane.setFont(new Font("monospaced", Font.PLAIN, 12));
+		textPane.setFont(new Font(Font.MONOSPACED, Font.PLAIN, textPane.getFont().getSize()));
 	}
 
 	// -- ItemTextPane methods --

--- a/src/main/java/org/scijava/ui/swing/viewer/text/SwingTextDisplayPanel.java
+++ b/src/main/java/org/scijava/ui/swing/viewer/text/SwingTextDisplayPanel.java
@@ -79,7 +79,7 @@ public class SwingTextDisplayPanel extends JScrollPane implements
 		textArea = new JEditorPane();
 		textArea.setPreferredSize(new Dimension(600, 500));
 		textArea.setEditable(false);
-		final Font font = new Font(Font.MONOSPACED, Font.PLAIN, 12);
+		final Font font = new Font(Font.MONOSPACED, Font.PLAIN, textArea.getFont().getSize());
 		textArea.setFont(font);
 		textArea.addHyperlinkListener(this);
 		setViewportView(textArea);


### PR DESCRIPTION
On Linux and Java 8, the imposed font size of 12 renders at an unbearable half on hiDPI screens.
This makes it so that the font size is always the default of the textarea/textpane.
While at it, this also adds some of LogPanel's contextual commands to ConsolePanel