### PR TITLE
OptionsLookAndFeel: Support for FlatLaf

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,6 +110,7 @@
 		<!-- NB: Deploy releases to the SciJava Maven repository. -->
 		<releaseProfiles>sign,deploy-to-scijava</releaseProfiles>
 
+		<flatlaf.version>2.4</flatlaf.version>
 		<jdatepicker.version>1.3.2</jdatepicker.version>
 		<object-inspector.version>0.1</object-inspector.version>
 	</properties>
@@ -156,6 +157,11 @@
 		<dependency>
 			<groupId>org.jfree</groupId>
 			<artifactId>jfreesvg</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.formdev</groupId>
+			<artifactId>flatlaf</artifactId>
+			<version>${flatlaf.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.github.sbridges.object-inspector</groupId>

--- a/src/main/java/org/scijava/ui/swing/options/OptionsLookAndFeel.java
+++ b/src/main/java/org/scijava/ui/swing/options/OptionsLookAndFeel.java
@@ -41,6 +41,11 @@ import javax.swing.UIManager;
 import javax.swing.UIManager.LookAndFeelInfo;
 import javax.swing.UnsupportedLookAndFeelException;
 
+import com.formdev.flatlaf.FlatLightLaf;
+import com.formdev.flatlaf.FlatDarkLaf;
+import com.formdev.flatlaf.FlatIntelliJLaf;
+import com.formdev.flatlaf.FlatDarculaLaf;
+
 import org.scijava.display.Display;
 import org.scijava.display.DisplayService;
 import org.scijava.log.LogService;
@@ -131,8 +136,15 @@ public class OptionsLookAndFeel extends OptionsPlugin {
 
 	protected void initLookAndFeel() {
 		final String lafClass = UIManager.getLookAndFeel().getClass().getName();
+		LookAndFeelInfo[] lookAndFeels = UIManager.getInstalledLookAndFeels();
 
-		final LookAndFeelInfo[] lookAndFeels = UIManager.getInstalledLookAndFeels();
+		// Make UIManager aware of FlatLaf look and feels, as needed
+		if (!isRegistered(lookAndFeels, FlatLightLaf.NAME)) FlatLightLaf.installLafInfo();
+		if (!isRegistered(lookAndFeels, FlatDarkLaf.NAME)) FlatDarkLaf.installLafInfo();
+		if (!isRegistered(lookAndFeels, FlatDarculaLaf.NAME)) FlatDarculaLaf.installLafInfo();
+		if (!isRegistered(lookAndFeels, FlatIntelliJLaf.NAME)) FlatIntelliJLaf.installLafInfo();
+		lookAndFeels = UIManager.getInstalledLookAndFeels(); // retrieve updated list
+
 		final ArrayList<String> lookAndFeelChoices = new ArrayList<>();
 		for (final LookAndFeelInfo lafInfo : lookAndFeels) {
 			final String lafName = lafInfo.getName();
@@ -148,6 +160,15 @@ public class OptionsLookAndFeel extends OptionsPlugin {
 	}
 
 	// -- Helper methods --
+
+	/** Assesses whether lookAndFeels contains the laf associated with lafName*/
+	private boolean isRegistered(final LookAndFeelInfo[] lookAndFeels, final String lafName) {
+		for (final LookAndFeelInfo lafInfo : lookAndFeels) {
+			if (lafInfo.getName().equals(lafName))
+				return true;
+		}
+		return false;
+	}
 
 	/** Tells all known Swing components to change to the new Look &amp; Feel. */
 	private void refreshSwingComponents() {
@@ -200,6 +221,41 @@ public class OptionsLookAndFeel extends OptionsPlugin {
 
 	private DisplayService displayService() {
 		return getContext().service(DisplayService.class);
+	}
+
+	/**
+	 * Sets the application look and feel.
+	 * <p>
+	 * Useful for setting up the look and feel early on in application startup
+	 * routine (e.g., through a macro or script)
+	 * </p>
+	 * 
+	 * @param lookAndFeel the look and feel. Supported values include "FlatLaf
+	 *                    Light", "FlatLaf Dark", "FlatLaf Darcula", "FlatLaf
+	 *                    IntelliJ", and JVM defaults
+	 *                    ("javax.swing.plaf.metal.MetalLookAndFeel", etc.)
+	 */
+	public static void setupLookAndFeel(final String lookAndFeel) {
+		switch (lookAndFeel) {
+		case FlatLightLaf.NAME:
+			FlatLightLaf.setup();
+			return;
+		case FlatDarkLaf.NAME:
+			FlatDarkLaf.setup();
+			return;
+		case FlatDarculaLaf.NAME:
+			FlatDarculaLaf.setup();
+			return;
+		case FlatIntelliJLaf.NAME:
+			FlatIntelliJLaf.setup();
+			return;
+		default:
+			try {
+				UIManager.setLookAndFeel(lookAndFeel);
+			} catch (final Exception ex) {
+				ex.printStackTrace();
+			}
+		}
 	}
 
 	// -- Deprecated methods --


### PR DESCRIPTION
@ctrueden, this PR is a proposal on how [Flatlaf](https://github.com/JFormDesigner/FlatLaf#flatlaf---flat-look-and-feel) could be used as an _optional_ L&F for Swing components in Fiji/SciJava in direct response to #61. The advantages of FlatLaf L&Fs are discussed in #61, and  include:
- Proper hiDPI scaling under Java 8 (this is mainly relevant to linux nowadays, but still relevant to other OSes: e.g., Native L&F on the mac scales everything without judgment, and so margins and borders become awkwardly exaggerated: this does not happen with FlatFlaf)
- Much more modern and polished 'feel' relative to JVM default options
- Several fixes for current Swing bugs and limitations that will not be fixed upstream
- Many improvements like[ improved submenu navigation](https://github.com/JFormDesigner/FlatLaf/releases/tag/2.1)
- Dark themes, that have been asked several times, e.g., in the script editor [here](https://forum.image.sc/t/shiny-new-script-editor/64160/37?u=tferr), and [here](https://github.com/scijava/script-editor/pull/56#issuecomment-1050888837)

This PR also includes a  static method so that Look and Feel can be set more easily at startup. E.g., for Fjii the following
call in the StartupMacros could now be used to set the Look and Feel programmatically:
```
eval("js","importClass(Packages.org.scijava.ui.swing.options.OptionsLookAndFeel);OptionsLookAndFeel.setupLookAndFeel('FlatLaf Dark');") 
```
A couple of notes:
- The flatlaf dependency is now being declared in this pom. I assume it should be declared in the parent pom-scijava? I imagine multiple releases of components would be needed, so if you don't mind I would pass that work onto you
- If this gets merged, dark themes in Fiji would still remain problematic. In addition to the obvious fact that  java.awt components will not change, there are currently some hardwired colors in several components (e.g., Console) that would need to be patched for dark themes to work properly. One would need to remove/adjust explicit `setColor()` references in the code. I am not doing that here, in case there are technical issues with adopting third-party L&F libraries that I am not foreseeing, and this cannot be merged.
- I would actually vote for FlatLaf to be the default in Fiji (for the reasons above). However, on the Mac AWT and Swing are too intertwined, and currently choosing a flatlaf theme on MacOS, makes some components of the GenericDialog loose rounded edges. So it may be wise for the time being to consider the possibility of having it as a default only on Windows and Linux. I will open an issue there to see if this can be fixed.