### PR TITLE
fix cancel not called when no user confirmation is required

### DIFF
--- a/src/main/java/org/scijava/ui/swing/task/SwingTaskMonitorComponent.java
+++ b/src/main/java/org/scijava/ui/swing/task/SwingTaskMonitorComponent.java
@@ -238,6 +238,8 @@ public class SwingTaskMonitorComponent {
 							if (userconfirmation == JOptionPane.YES_OPTION) {
 								selectedTask.cancel("User cancellation (table task)");
 							}
+						} else {
+							selectedTask.cancel("User cancellation (table task)");
 						}
 					}
 				}


### PR DESCRIPTION
Fixing a stupid mistake I made in the previous PR (https://github.com/scijava/scijava-ui-swing/pull/67)