### PR TITLE
L&F adjustments and improvements

### DIFF
--- a/src/main/java/org/scijava/ui/swing/console/ConsolePanel.java
+++ b/src/main/java/org/scijava/ui/swing/console/ConsolePanel.java
@@ -41,7 +41,7 @@ import javax.swing.JPopupMenu;
 import javax.swing.JScrollPane;
 import javax.swing.JTextArea;
 import javax.swing.JTextPane;
-import javax.swing.KeyStroke;
+import javax.swing.UIManager;
 import javax.swing.text.BadLocationException;
 import javax.swing.text.Style;
 import javax.swing.text.StyleConstants;
@@ -117,12 +117,12 @@ public class ConsolePanel extends JPanel implements OutputListener
 
 		doc = textPane.getStyledDocument();
 
-		stdoutLocal = createStyle("stdoutLocal", null, Color.black, null, null);
-		stderrLocal = createStyle("stderrLocal", null, Color.red, null, null);
+		stdoutLocal = createStyle("stdoutLocal", null, defaultFontColor(), null, null);
+		stderrLocal = createStyle("stderrLocal", null, Color.RED, null, null);
 		stdoutGlobal = createStyle("stdoutGlobal", stdoutLocal, null, null, true);
 		stderrGlobal = createStyle("stderrGlobal", stderrLocal, null, null, true);
 
-		// NB: We wrap the JTextPane in a JPanel to disable
+		// NB: We wrap the JTextPane in a JPanel to disable 
 		// the text pane's intelligent line wrapping behavior.
 		// I.e.: we want console lines _not_ to wrap, but instead
 		// for the scroll pane to show a horizontal scroll bar.
@@ -147,17 +147,30 @@ public class ConsolePanel extends JPanel implements OutputListener
 	private JPopupMenu initMenu() {
 		final JPopupMenu menu = new JPopupMenu();
 		JMenuItem item = new JMenuItem("Copy");
-		item.setAccelerator(KeyStroke.getKeyStroke("control C"));
-		item.addActionListener( e-> textPane.copy());
+		item.addActionListener(e -> textPane.copy());
 		menu.add(item);
 		item = new JMenuItem("Clear");
-		item.setAccelerator(KeyStroke.getKeyStroke("alt C"));
 		item.addActionListener(e -> clear());
+		menu.add(item);
+		item = new JMenuItem("Select All");
+		item.addActionListener(e -> textPane.selectAll());
 		menu.add(item);
 		return menu;
 	}
 
+	@Override
+	public void updateUI() {
+		if (stdoutLocal != null)
+			StyleConstants.setForeground(stdoutLocal, defaultFontColor());
+		super.updateUI();
+	}
+
 	// -- Helper methods --
+
+	private static Color defaultFontColor() {
+		final Color color = UIManager.getColor("TextPane.foreground");
+		return (color == null) ? Color.BLACK : color;
+	}
 
 	private Style createStyle(final String name, final Style parent,
 							  final Color foreground, final Boolean bold, final Boolean italic)

--- a/src/main/java/org/scijava/ui/swing/console/LogSourcesPanel.java
+++ b/src/main/java/org/scijava/ui/swing/console/LogSourcesPanel.java
@@ -146,22 +146,22 @@ class LogSourcesPanel extends JPanel {
 	}
 
 	private JButton initVisibilityButton() {
-		JButton button = new JButton("visibility");
+		JButton button = new JButton("Visibility");
 		button.addActionListener(a -> menu.show(button, 0, button.getHeight()));
 		return button;
 	}
 
 	private void initMenu() {
 		EnumSet<Level> levels = EnumSet.range(Level.ERROR, Level.TRACE);
-		addMenuItemPerLevel(EnumSet.of(Level.TRACE), level -> "show all",
+		addMenuItemPerLevel(EnumSet.of(Level.TRACE), level -> "Show all",
 			this::onShowErrorUpToClicked);
-		addMenuItemPerLevel(EnumSet.of(Level.NONE), level -> "hide all",
+		addMenuItemPerLevel(EnumSet.of(Level.NONE), level -> "Hide all",
 			this::onShowNoneClicked);
 		menu.addSeparator();
-		addMenuItemPerLevel(levels, level -> "show " + level.toString(),
+		addMenuItemPerLevel(levels, level -> "Show " + level.toString(),
 			this::onShowLogLevelClicked);
 		menu.addSeparator();
-		addMenuItemPerLevel(levels, level -> "hide " + level.toString(),
+		addMenuItemPerLevel(levels, level -> "Hide " + level.toString(),
 			this::onHideLogLevelClicked);
 		menu.addSeparator();
 		addMenuItemPerLevel(levels, LogSourcesPanel::listLevelsErrorTo,

--- a/src/main/java/org/scijava/ui/swing/console/LoggingPanel.java
+++ b/src/main/java/org/scijava/ui/swing/console/LoggingPanel.java
@@ -49,12 +49,10 @@ import javax.swing.JMenu;
 import javax.swing.JMenuItem;
 import javax.swing.JPanel;
 import javax.swing.JPopupMenu;
-import javax.swing.JSeparator;
 import javax.swing.JSplitPane;
 import javax.swing.JTextPane;
 import javax.swing.KeyStroke;
-import javax.swing.SwingConstants;
-import javax.swing.plaf.basic.BasicArrowButton;
+import javax.swing.UIManager;
 import javax.swing.text.AttributeSet;
 import javax.swing.text.MutableAttributeSet;
 import javax.swing.text.SimpleAttributeSet;
@@ -89,7 +87,7 @@ public class LoggingPanel extends JPanel implements LogListener
 {
 	private static final AttributeSet STYLE_ERROR = normal(new Color(200, 0, 0));
 	private static final AttributeSet STYLE_WARN = normal(new Color(200, 140, 0));
-	private static final AttributeSet STYLE_INFO = normal(Color.BLACK);
+	private static final AttributeSet STYLE_INFO = normal(defaultInfoColor());
 	private static final AttributeSet STYLE_DEBUG = normal(new Color(0, 0, 200));
 	private static final AttributeSet STYLE_TRACE = normal(Color.GRAY);
 	private static final AttributeSet STYLE_OTHERS = normal(Color.GRAY);
@@ -173,6 +171,12 @@ public class LoggingPanel extends JPanel implements LogListener
 		updateFilter();
 	}
 
+	@Override
+	public void updateUI() {
+		StyleConstants.setForeground((MutableAttributeSet) STYLE_INFO, defaultInfoColor());
+		super.updateUI();
+	}
+
 	// -- LogListener methods --
 
 	@Override
@@ -183,12 +187,17 @@ public class LoggingPanel extends JPanel implements LogListener
 
 	// -- Helper methods --
 
+	private static Color defaultInfoColor() {
+		final Color color = UIManager.getColor("TextPane.foreground");
+		return (color == null) ? Color.BLACK : color;
+	}
+
 	private void initGui() {
 		textFilter.setChangeListener(this::updateFilter);
 
 		JPopupMenu menu = initMenu();
 
-		JButton menuButton = new BasicArrowButton(SwingConstants.SOUTH);
+		JButton menuButton = new JButton("\u22EE");
 		menuButton.addActionListener(a ->
 			menu.show(menuButton, 0, menuButton.getHeight()));
 
@@ -216,7 +225,7 @@ public class LoggingPanel extends JPanel implements LogListener
 	}
 
 	private LogSourcesPanel initSourcesPanel() {
-		JButton reloadButton = new JButton("reload");
+		JButton reloadButton = new JButton("Reload");
 		reloadButton.addActionListener(actionEvent -> reloadSources());
 		return new LogSourcesPanel(reloadButton);
 	}
@@ -254,12 +263,12 @@ public class LoggingPanel extends JPanel implements LogListener
 
 	private JMenu initSettingsMenu() {
 		JMenu menu = new JMenu("Settings");
-		menu.add(checkboxItem(LogFormatter.Field.TIME, "show time stamp"));
-		menu.add(checkboxItem(LogFormatter.Field.SOURCE, "show log source"));
-		menu.add(checkboxItem(LogFormatter.Field.LEVEL, "show log level"));
-		menu.add(checkboxItem(LogFormatter.Field.THROWABLE, "show exception"));
-		menu.add(checkboxItem(LogFormatter.Field.ATTACHMENT, "show attached data"));
-		menu.add(new JSeparator());
+		menu.add(checkboxItem(LogFormatter.Field.TIME, "Show time stamp"));
+		menu.add(checkboxItem(LogFormatter.Field.SOURCE, "Show log source"));
+		menu.add(checkboxItem(LogFormatter.Field.LEVEL, "Show log level"));
+		menu.add(checkboxItem(LogFormatter.Field.THROWABLE, "Show exception"));
+		menu.add(checkboxItem(LogFormatter.Field.ATTACHMENT, "Show attached data"));
+		menu.addSeparator();
 		menu.add(recordCallingClassMenuItem());
 		return menu;
 	}
@@ -267,7 +276,7 @@ public class LoggingPanel extends JPanel implements LogListener
 	private JCheckBoxMenuItem recordCallingClassMenuItem() {
 		JCheckBoxMenuItem menuItem = new JCheckBoxMenuItem();
 		menuItem.setState(false);
-		menuItem.setAction(new AbstractAction("record calling class") {
+		menuItem.setAction(new AbstractAction("Record calling class") {
 			@Override
 			public void actionPerformed(ActionEvent e) {
 				recorder.setRecordCallingClass(menuItem.getState());

--- a/src/main/java/org/scijava/ui/swing/console/SwingConsolePane.java
+++ b/src/main/java/org/scijava/ui/swing/console/SwingConsolePane.java
@@ -148,7 +148,7 @@ public class SwingConsolePane extends AbstractConsolePane<JPanel> {
 		consolePanel = new ConsolePanel(context);
 		loggingPanel = new LoggingPanel(context, LOG_FORMATTING_SETTINGS_KEY);
 		logService.addLogListener(loggingPanel);
-		component = new JPanel(new MigLayout("", "[grow]", "[grow]"));
+		component = new JPanel(new MigLayout("insets 0", "[grow]", "[grow]"));
 		JTabbedPane tabs = new JTabbedPane();
 		tabs.addTab("Console", consolePanel);
 		tabs.addTab("Log", loggingPanel);

--- a/src/main/java/org/scijava/ui/swing/options/OptionsLookAndFeel.java
+++ b/src/main/java/org/scijava/ui/swing/options/OptionsLookAndFeel.java
@@ -44,6 +44,7 @@ import javax.swing.UnsupportedLookAndFeelException;
 import com.formdev.flatlaf.FlatLightLaf;
 import com.formdev.flatlaf.FlatDarkLaf;
 import com.formdev.flatlaf.FlatIntelliJLaf;
+import com.formdev.flatlaf.FlatLaf;
 import com.formdev.flatlaf.FlatDarculaLaf;
 
 import org.scijava.display.Display;
@@ -236,24 +237,26 @@ public class OptionsLookAndFeel extends OptionsPlugin {
 	 *                    ("javax.swing.plaf.metal.MetalLookAndFeel", etc.)
 	 */
 	public static void setupLookAndFeel(final String lookAndFeel) {
-		switch (lookAndFeel) {
+		switch (lookAndFeel) { // FIXME: should FlatLaf.updateUI() calls be replaced with updateUILater()?
 		case FlatLightLaf.NAME:
-			FlatLightLaf.setup();
+			if (FlatLightLaf.setup()) FlatLightLaf.updateUI();
 			return;
 		case FlatDarkLaf.NAME:
-			FlatDarkLaf.setup();
+			if (FlatDarkLaf.setup()) FlatDarkLaf.updateUI();
 			return;
 		case FlatDarculaLaf.NAME:
-			FlatDarculaLaf.setup();
+			if (FlatDarculaLaf.setup()) FlatDarculaLaf.updateUI();
 			return;
 		case FlatIntelliJLaf.NAME:
-			FlatIntelliJLaf.setup();
+			if (FlatIntelliJLaf.setup()) FlatIntelliJLaf.updateUI();
 			return;
 		default:
 			try {
 				UIManager.setLookAndFeel(lookAndFeel);
+				FlatLaf.updateUI();
 			} catch (final Exception ex) {
 				ex.printStackTrace();
+				FlatLaf.revalidateAndRepaintAllFramesAndDialogs(); // Recover from possible ill-states
 			}
 		}
 	}


### PR DESCRIPTION
This implements a couple of minor improvements related to the new L&F options:
- OptionsLookAndFeel: `setupLookAndFeel()` calls now updateUI
- Console:
  - Ensure default font is readable with dark themes (do not use hardwired foreground colors for default fonts)
  - Reduce margins of JTabbedPane for better usage of screen real estate
  - LogPanel: Replace non-scalable (icon based) button with scalable (font based) button
  - More consistent capitalization of menu items
  - Do not list inactive accelerators in contextual menu

Some snapshots under light & dark L&Fs:
![image](https://user-images.githubusercontent.com/2439948/189034487-ec126bb0-a12b-48c1-a3e0-2746354c58a4.png)
![image](https://user-images.githubusercontent.com/2439948/189034589-5322eb76-56c5-42fb-a16c-de626bb85c74.png)
