### PR TITLE
Laf fixes

### DIFF
--- a/src/main/java/org/scijava/ui/swing/console/ConsolePanel.java
+++ b/src/main/java/org/scijava/ui/swing/console/ConsolePanel.java
@@ -132,12 +132,12 @@ public class ConsolePanel extends JPanel implements OutputListener
 		textPanel.add(textPane);
 
 		scrollPane = new JScrollPane(textPanel);
-		scrollPane.setPreferredSize(new Dimension(600, 600));
 
 		// Make the scroll bars move at a reasonable pace.
-		final FontMetrics fm = scrollPane.getFontMetrics(scrollPane.getFont());
+		final FontMetrics fm = scrollPane.getFontMetrics(textPane.getFont());
 		final int charWidth = fm.charWidth('a');
 		final int lineHeight = fm.getHeight();
+		scrollPane.setPreferredSize(new Dimension(charWidth * 80, lineHeight * 10)); //80 columns, 10 lines
 		scrollPane.getHorizontalScrollBar().setUnitIncrement(charWidth);
 		scrollPane.getVerticalScrollBar().setUnitIncrement(2 * lineHeight);
 		textPane.setComponentPopupMenu(initMenu());

--- a/src/main/java/org/scijava/ui/swing/widget/SwingColorWidget.java
+++ b/src/main/java/org/scijava/ui/swing/widget/SwingColorWidget.java
@@ -46,6 +46,7 @@ import javax.swing.JButton;
 import javax.swing.JColorChooser;
 import javax.swing.JDialog;
 import javax.swing.JPanel;
+import javax.swing.UIManager;
 import javax.swing.colorchooser.AbstractColorChooserPanel;
 
 import org.scijava.plugin.Plugin;
@@ -66,7 +67,7 @@ public class SwingColorWidget extends SwingInputWidget<ColorRGB> implements
 	ActionListener, ColorWidget<JPanel>
 {
 
-	private static final int SWATCH_WIDTH = 64, SWATCH_HEIGHT = 16;
+	private static final int SWATCH_WIDTH = 64, SWATCH_HEIGHT = widgetHeight();
 
 	private static final String HSB_CLASS_NAME =
 		"javax.swing.colorchooser.DefaultHSBChooserPanel";
@@ -209,6 +210,15 @@ public class SwingColorWidget extends SwingInputWidget<ColorRGB> implements
 		chooser.setChooserPanels(panels);
 
 		return chooser;
+	}
+
+	private static int widgetHeight() {
+		try {
+			return UIManager.getFont("TextField.font").getSize();
+		} catch (final Exception ignored) {
+			// do nothing
+		}
+		return 16;
 	}
 
 	// -- AbstractUIInputWidget methods ---

--- a/src/main/java/org/scijava/ui/swing/widget/SwingNumberWidget.java
+++ b/src/main/java/org/scijava/ui/swing/widget/SwingNumberWidget.java
@@ -128,7 +128,7 @@ public class SwingNumberWidget extends SwingInputWidget<Number> implements
 		}
 		spinner.setEditor(new JSpinner.NumberEditor(spinner, format));
 
-		Dimension spinnerSize = spinner.getSize();
+		Dimension spinnerSize = spinner.getPreferredSize();
 		spinnerSize.width = 50;
 		spinner.setPreferredSize(spinnerSize);
 		fixSpinner(type);


### PR DESCRIPTION
I finally looked into things that are not scaling properly under FlatLaf.  I found only 3 issues, each associated with one commit here, to make it easier to cherrypick things.

#### Console
Commit 37a3cb2c971608a32ca406b044308ad4e078d6fd: The console dimensions were hardwired, so I tried to make it so that dimensions are set in terms of columns/lines computed from the active monospaced font. Also the menu bar contains only a single "Clear" command. I find this confusing because that clear command does nothing when the Log tab is selected. Since there is a 'Clear' command in the contextual menus of both tabs, I propose we remove it.

#### Color widgets
Commit 01459f8b50a6f48521831a66d57533f401fbac93: It was using a hardwired height. Now it is scalable, with height matching that of a JTextField. https://github.com/imagej/imagej-ui-swing/pull/90 extends this to color tables

#### Number widgets
Commit 95bc9b3bb9742f8d3bec3fa040a9a1c549f24b67: I could not find any reason why this code (discussed in #77) needs to exist: https://github.com/scijava/scijava-ui-swing/blob/40bd474d8b9b169d521a621ddf9772a718ce6e26/src/main/java/org/scijava/ui/swing/widget/SwingNumberWidget.java#L131-L133
A width of 50 seems arbitrary, and everything seems to work fine if we just remove that code!? @imagejan, what do you think?

#### FileList widgets
`SwingFileListWidget` was the other place where I found hardwired dimensions, namely here:
https://github.com/scijava/scijava-ui-swing/blob/47c0e91dbd3a22e8d46e9da812593652754252a6/src/main/java/org/scijava/ui/swing/widget/SwingFileListWidget.java#L115
(@imagejan, without specifying dimensions the JscrollPane does collapse, but perhaps something like `JList#setPrototypeCellValue("prototype value");` could be used to set things in a 'scalable' manner?

(update: edited for clarity)