### PR TITLE
Make file filter show the extension, instead of cryptic stuff

### DIFF
--- a/src/main/java/org/scijava/ui/swing/widget/SwingFileWidget.java
+++ b/src/main/java/org/scijava/ui/swing/widget/SwingFileWidget.java
@@ -40,6 +40,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.StringJoiner;
 import java.util.stream.Collectors;
 
 import javax.swing.Box;
@@ -235,7 +236,22 @@ public class SwingFileWidget extends SwingInputWidget<File> implements
 				}
 				return false;
 			}
+
+			@Override
+			public String toString() {
+				return formatFileFilterExtensions( exts );
+			}
 		};
+	}
+
+	static String formatFileFilterExtensions( final List< String > extensions ) {
+		List< String > extsWithPrefix = new ArrayList<>();
+		for ( String extension : extensions ) {
+			extsWithPrefix.add( "*." + extension );
+		}
+		StringJoiner joiner = new StringJoiner( ";" );
+		extsWithPrefix.forEach( joiner::add );
+		return joiner.toString();
 	}
 
 	/**

--- a/src/test/java/org/scijava/ui/swing/widget/SwingFileWidgetTest.java
+++ b/src/test/java/org/scijava/ui/swing/widget/SwingFileWidgetTest.java
@@ -1,0 +1,21 @@
+package org.scijava.ui.swing.widget;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class SwingFileWidgetTest
+{
+
+	@Test
+	public void testFormatFileFilterExtensions() {
+		final List< String > multipleExtensions = Arrays.asList( "jpg", "jpeg", "png", "gif", "bmp" );
+		final List< String > singleExtension = Collections.singletonList( "xml" );
+		assertEquals( "*.jpg;*.jpeg;*.png;*.gif;*.bmp", SwingFileWidget.formatFileFilterExtensions( multipleExtensions ) );
+		assertEquals( "*.xml", SwingFileWidget.formatFileFilterExtensions( singleExtension ) );
+	}
+}


### PR DESCRIPTION
* Override FileFilter toString() method in SwingFileWidget so that it shows the extension(s) that are filtered by the file choose dialog instead of the standard toString() method
* Related to
  * https://github.com/bigdataviewer/bigdataviewer-playground/issues/110
  * https://forum.image.sc/t/scijava-command-file-extensions/29869/2
* Before this PR: ![grafik](https://github.com/scijava/scijava-ui-swing/assets/10515534/955209d6-4c5d-4da9-91be-d5c8fee706e1)
* After this PR: ![grafik](https://github.com/scijava/scijava-ui-swing/assets/10515534/3a37c79f-4b0c-4c49-abc0-1e00021d386c)
 