### PR TITLE
Enable FileWidget.FILE_AND_DIRECTORY_STYLE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,11 @@
 			<url>https://imagej.net/people/NicoKiaru</url>
 			<properties><id>NicoKiaru</id></properties>
 		</contributor>
+		<contributor>
+			<name>Christian Tischer</name>
+			<url>https://imagej.net/people/tischi</url>
+			<properties><id>tischi</id></properties>
+		</contributor>
 	</contributors>
 
 	<mailingLists>
@@ -126,6 +131,7 @@
 		<dependency>
 			<groupId>org.scijava</groupId>
 			<artifactId>scijava-common</artifactId>
+			<version>2.99.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.scijava</groupId>

--- a/src/main/java/org/scijava/ui/swing/AbstractSwingUI.java
+++ b/src/main/java/org/scijava/ui/swing/AbstractSwingUI.java
@@ -145,7 +145,7 @@ public abstract class AbstractSwingUI extends AbstractUserInterface implements
 				final JFileChooser chooser = new JFileChooser(file);
 				if (FileWidget.DIRECTORY_STYLE.equals(style)) {
 					chooser.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
-				} else if (FileWidget.FILES_AND_DIRECTORIES.equals(style)) {
+				} else if (FileWidget.FILE_AND_DIRECTORY_STYLE.equals(style)) {
 					chooser.setFileSelectionMode(JFileChooser.FILES_AND_DIRECTORIES);
 				}
 				final int rval;

--- a/src/main/java/org/scijava/ui/swing/AbstractSwingUI.java
+++ b/src/main/java/org/scijava/ui/swing/AbstractSwingUI.java
@@ -145,6 +145,8 @@ public abstract class AbstractSwingUI extends AbstractUserInterface implements
 				final JFileChooser chooser = new JFileChooser(file);
 				if (FileWidget.DIRECTORY_STYLE.equals(style)) {
 					chooser.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
+				} else if (FileWidget.FILES_AND_DIRECTORIES.equals(style)) {
+					chooser.setFileSelectionMode(JFileChooser.FILES_AND_DIRECTORIES);
 				}
 				final int rval;
 				if (FileWidget.SAVE_STYLE.equals(style)) {

--- a/src/main/java/org/scijava/ui/swing/widget/SwingFileWidget.java
+++ b/src/main/java/org/scijava/ui/swing/widget/SwingFileWidget.java
@@ -127,8 +127,8 @@ public class SwingFileWidget extends SwingInputWidget<File> implements
 		final String style;
 		if (model.isStyle(FileWidget.DIRECTORY_STYLE)) {
 			style = FileWidget.DIRECTORY_STYLE;
-		} else if (model.isStyle(FileWidget.FILES_AND_DIRECTORIES)) {
-			style = FileWidget.FILES_AND_DIRECTORIES;
+		} else if (model.isStyle(FileWidget.FILE_AND_DIRECTORY_STYLE)) {
+			style = FileWidget.FILE_AND_DIRECTORY_STYLE;
 		} else if (model.isStyle(FileWidget.SAVE_STYLE)) {
 			style = FileWidget.SAVE_STYLE;
 		} else {
@@ -180,8 +180,9 @@ public class SwingFileWidget extends SwingInputWidget<File> implements
 	 * <ul>
 	 * <li>{@link FileWidget#OPEN_STYLE}</li>
 	 * <li>{@link FileWidget#SAVE_STYLE}</li>
-	 * <li>{@link FileListWidget#FILES_ONLY}</li>
 	 * <li>{@link FileWidget#DIRECTORY_STYLE}</li>
+	 * <li>{@link FileWidget#FILE_AND_DIRECTORY_STYLE}</li>
+	 * <li>{@link FileListWidget#FILES_ONLY}</li>
 	 * <li>{@link FileListWidget#DIRECTORIES_ONLY}</li>
 	 * <li>{@link FileListWidget#FILES_AND_DIRECTORIES}</li>
 	 * </ul>
@@ -199,7 +200,7 @@ public class SwingFileWidget extends SwingInputWidget<File> implements
 			FileWidget.DIRECTORY_STYLE, FileListWidget.DIRECTORIES_ONLY
 		);
 		final List<String> filesAndDirsStyles = Arrays.asList(
-			FileWidget.FILES_AND_DIRECTORIES, FileListWidget.FILES_AND_DIRECTORIES
+			FileWidget.FILE_AND_DIRECTORY_STYLE, FileListWidget.FILES_AND_DIRECTORIES
 		);
 
 		final List<String> exts = new ArrayList<>();

--- a/src/main/java/org/scijava/ui/swing/widget/SwingFileWidget.java
+++ b/src/main/java/org/scijava/ui/swing/widget/SwingFileWidget.java
@@ -127,11 +127,11 @@ public class SwingFileWidget extends SwingInputWidget<File> implements
 		final String style;
 		if (model.isStyle(FileWidget.DIRECTORY_STYLE)) {
 			style = FileWidget.DIRECTORY_STYLE;
-		}
-		else if (model.isStyle(FileWidget.SAVE_STYLE)) {
+		} else if (model.isStyle(FileWidget.FILES_AND_DIRECTORIES)) {
+			style = FileWidget.FILES_AND_DIRECTORIES;
+		} else if (model.isStyle(FileWidget.SAVE_STYLE)) {
 			style = FileWidget.SAVE_STYLE;
-		}
-		else {
+		} else {
 			style = FileWidget.OPEN_STYLE;
 		}
 		file = uiService.chooseFile(file, style);
@@ -199,7 +199,7 @@ public class SwingFileWidget extends SwingInputWidget<File> implements
 			FileWidget.DIRECTORY_STYLE, FileListWidget.DIRECTORIES_ONLY
 		);
 		final List<String> filesAndDirsStyles = Arrays.asList(
-			FileListWidget.FILES_AND_DIRECTORIES
+			FileWidget.FILES_AND_DIRECTORIES, FileListWidget.FILES_AND_DIRECTORIES
 		);
 
 		final List<String> exts = new ArrayList<>();

--- a/src/test/java/org/scijava/ui/swing/command/FileAndDirectoryChooserCommandDemo.java
+++ b/src/test/java/org/scijava/ui/swing/command/FileAndDirectoryChooserCommandDemo.java
@@ -1,0 +1,59 @@
+/*-
+ * #%L
+ * SciJava UI components for Java Swing.
+ * %%
+ * Copyright (C) 2010 - 2023 SciJava developers.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package org.scijava.ui.swing.command;
+
+import org.scijava.Context;
+import org.scijava.command.Command;
+import org.scijava.command.CommandService;
+import org.scijava.command.InteractiveCommand;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+import org.scijava.ui.UIService;
+
+import java.io.File;
+
+@Plugin(type = Command.class, menuPath = "Test>File and Directory Chooser Command")
+public class FileAndDirectoryChooserCommandDemo implements Command {
+
+    @Parameter (style = "both")
+    File file;
+
+    @Override
+    public void run() {
+        System.out.println("You chose: " + file.toString());
+    }
+
+    public static void main(String... args) throws Exception {
+
+        Context context = new Context();
+        context.service(UIService.class).showUI();
+        context.service(CommandService.class).run( FileAndDirectoryChooserCommandDemo.class, true);
+
+    }
+}


### PR DESCRIPTION
Depends on https://github.com/scijava/scijava-common/pull/480

Choosing both a file or a directory works on my Mac within the [FileAndDirectoryChooserCommandDemo](https://github.com/tischi/scijava-ui-swing/blob/fix-issue-83/src/test/java/org/scijava/ui/swing/command/FileAndDirectoryChooserCommandDemo.java), which I added to the code.